### PR TITLE
Require Python 3.8+ and switch to native namespace packages.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changelog
 =========
 
-1.6.1 (unreleased)
-------------------
+2.0.0a1 (unreleased)
+--------------------
 
-- Nothing changed yet.
+- Require Python 3.8+ and switch to native namespace packages.
+  This is needed because ``zest.releaser`` 9.0.0a1 does the same.
+  [maurits]
 
 
 1.6.0 (2022-09-13)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.isort]
+profile = "plone"
+
+[tool.black]
+target-version = ["py38"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,28 @@
-from setuptools import find_packages
+from pathlib import Path
 from setuptools import setup
 
 
-version = "1.6.1.dev0"
+version = "2.0.0a1.dev0"
+long_description = (
+    f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}\n"
+)
 
 setup(
     name="zest.pocompile",
     version=version,
     description="Compile po files when releasing a package",
-    long_description=(open("README.rst").read() + "\n" + open("CHANGES.rst").read()),
+    long_description=long_description,
     # Get more strings from https://pypi.org/classifiers/
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Buildout",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Internationalization",
     ],
     keywords="i18n locales po compile release",
@@ -28,10 +30,10 @@ setup(
     author_email="m.van.rees@zestsoftware.nl",
     url="https://github.com/zestsoftware/zest.pocompile",
     license="GPL",
-    packages=find_packages(exclude=["ez_setup"]),
-    namespace_packages=["zest"],
+    packages=["zest.pocompile"],
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.8",
     install_requires=["setuptools", "python-gettext"],
     entry_points={
         "console_scripts": ["pocompile = zest.pocompile.compile:main"],

--- a/zest/__init__.py
+++ b/zest/__init__.py
@@ -1,7 +1,0 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-
-    __path__ = extend_path(__path__, __name__)

--- a/zest/pocompile/compile.py
+++ b/zest/pocompile/compile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Compiles po files.
 
 This walks through the given directories, finds all po translation
@@ -100,8 +99,7 @@ def compile_in_tag(data):
 
 
 def main(*args, **kwargs):
-    """Run as stand-alone program.
-    """
+    """Run as stand-alone program."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     # Parsing arguments.  Note that the parse_args call might already


### PR DESCRIPTION
This is needed because ``zest.releaser`` 9.0.0a1 does the same.